### PR TITLE
Add Applicative support to Result

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/leonardoborges/imminent"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0-beta1"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/test.check "0.5.8"]
                  [uncomplicate/fluokitten "0.3.0"]
                  [org.clojure/core.match "0.2.1"]]

--- a/project.clj
+++ b/project.clj
@@ -7,4 +7,5 @@
                  [org.clojure/test.check "0.5.8"]
                  [uncomplicate/fluokitten "0.3.0"]
                  [org.clojure/core.match "0.2.1"]]
-  :plugins [[codox "0.8.10"]])
+  :plugins [[codox "0.8.10"]]
+  :profiles {:dev {:dependencies [[midje "1.6.3"]]}})

--- a/test/imminent/result_midje_test.clj
+++ b/test/imminent/result_midje_test.clj
@@ -1,0 +1,58 @@
+(ns imminent.result-midje-test
+  (:require [uncomplicate.fluokitten.core :refer [fmap, fapply, mdo, return,
+                                                  pure]]
+            [uncomplicate.fluokitten.test :as ft]
+            [midje.sweet :refer :all]
+            [imminent.result :refer [success, failure]]))
+
+(fact "success laws"
+      ;; --- Functor ---
+      (fact "first functor law"
+            (fmap identity (success 1)) => (success 1))
+      (ft/functor-law2 inc (partial * 2) (success 42))
+
+      ;; --- Applicative ---
+      (ft/applicative-law1 inc (success 1))
+      (ft/applicative-law2-identity (success 1))
+      (ft/applicative-law3-composition (success inc)
+                                       (success (partial * 2))
+                                       (success 42))
+      (ft/applicative-law4-homomorphism (success "dummy value")
+                                        (partial * 2)
+                                        42)
+      (ft/applicative-law5-interchange (success "dummy value")
+                                       (partial * 2)
+                                       42)
+      (ft/fapply-keeps-type (partial * 2) (success 1))
+
+      ;; --- Monad ---
+      (ft/monad-law1-left-identity (success "dummy value")
+                                   (comp success inc)
+                                   42)
+      (ft/monad-law2-right-identity (success 1))
+      (ft/monad-law3-associativity (comp success inc)
+                                   (comp success (partial * 2))
+                                   (success 1)))
+
+(fact "monadic actions on success and failure"
+
+      (fact "a successful return places results into a success"
+            (mdo [x (success 1)]
+                 (return (* 2 x))
+                 ) => (success 2))
+
+      (fact "a failure short-circuits"
+            (mdo [x (failure "a failure")]
+                 (return (* 2 x))
+                 ) => (failure "a failure"))
+
+      (fact "fmap acts correctly on success/failure"
+            (fmap inc (success 1))       => (success 2)
+            (fmap inc (failure "error")) => (failure "error"))
+
+      (fact "fapply works for success/failure"
+            (let [inc-lifted (success inc)]
+              (fapply inc-lifted (success 1))       => (success 2)
+              (fapply inc-lifted (failure "error")) => (failure "error")))
+
+      )


### PR DESCRIPTION
This adds Applicative to Result; primarily to allow the fluokitten `return` function to be used with it.

There is a minor Clojure version bump from `1.7.0-beta1` to `1.7.0`, to satisfy the current Cider implementation in emacs, which requires `1.7.0` as a minimum.

fluokitten provides some law tests in the Midje framework, so a module which employs these tests for Result has been added. These tests appear to function well along-side the existing tests.

### Observations on the split between Success and Failure

Although they can exist as independent monads, for them to be useful, Success and Failure need to be part of the same applicative / monad.

Failure by itself would be a null instance, which could not be fmapped-over or bound (this is reflected in the current implementation). Success by itself would be a cell value, equivalent to a single-element collection. Thus, they only become useful when working as a unified applicative / monad.

Splitting them leads to a situation where a sensible implementation of `fapply` requires information from both. Because `fapply` takes two arguments that exist in the applicative / monadic context, which can both be either `Success` or `Failure`, it was not possible to dispatch based on the type of just one of them, as was previously done with functor.